### PR TITLE
Fix sidebar's accommodation page route path

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -17,7 +17,7 @@ const SIDEBAR_ITEM = [
     subItems: [
       { name: "行前必讀", href: "/volunteer/preparation" },
       { name: "交通資訊", href: "/volunteer/transportation" },
-      { name: "住宿資訊", href: "/map?view=list" },
+      { name: "住宿資訊", href: "/map?view=list&category=accommodations" },
     ],
   },
   {


### PR DESCRIPTION
## Summary
<!-- 用一句話描述這個 PR 的目的 -->
e.g. Add new date picker component for report filtering

把 Sidebar 的住宿資訊連到 map listView 的住宿分頁


## Context / Motivation
<!-- 為什麼要做這個改動？解決什麼問題？ -->
- [ ] Issue / Ticket: QA List No. 18
- [ ] 背景說明：
- [ ] 預期結果 / 改善目標：

點 Sidebar 的住宿資訊，他現在是跳到 map list View 的頭，但頁面 tab 上點過去的是直接進到 map listView 的住宿頁
需要把兩邊的行為 align


## Main Changes
<!-- 請條列主要修改項目 -->
- [ ] ✨ 新增元件：
- [ ] 🎨 UI / Layout 調整：
- [ ] 🧠 狀態管理 / 邏輯更新：
- [ ] 🐛 修正 Bug：把 sidebar 的連結改掉成 map listView 住宿頁的
- [ ] 📄 文件 / 註解更新：

**詳細說明：**
1. 
2. 
3. 


## Test Plan
<!-- 如何驗證這個 PR 的功能正常 -->
- [ ] 本地測試通過
- [ ] Unit / E2E 測試已更新
- [ ] 手動驗證流程：
  1. 打開頁面 ___
  2. 點擊按鈕 ___
  3. 檢查結果 ___
- [ ] 可附 Demo 或錄影：

![screenshots](https://github.com/user-attachments/assets/0f045262-6dd3-487f-8287-b3f2ff2816e6)


## 🔗 Related Links
- Design / Figma:
- Product Spec / Notion Doc:
- Related PRs:


## Checklist
- [ ] 通過 lint / build / test
- [ ] 無多餘 console.log 或暫時註解
- [ ] 程式碼命名與 Style 一致
- [ ] 已考慮例外情境與邊界狀況
- [ ] 有加上適當的型別與註解
- [ ] 若涉及 API，有同步更新對應 schema


## Reviewer Focus
<!-- 請 reviewer 特別注意的部分 -->
- [ ] UI 一致性
- [ ] 邏輯正確性
- [ ] 效能表現
- [ ] 型別安全性
- [ ] 文件與可維護性
